### PR TITLE
Fix writing to bigwig.

### DIFF
--- a/bin/bam_cov.py
+++ b/bin/bam_cov.py
@@ -1407,7 +1407,7 @@ class GenomeCoverage:
         """
 
     # choose bigwig or h5
-    if os.path.splitext(output_file)[1] == 'bw':
+    if os.path.splitext(output_file)[1] == '.bw':
       print('Outputting coverage to BigWig')
       bigwig = True
       cov_out = pyBigWig.open(output_file, 'w')


### PR DESCRIPTION
Splitext includes the leading period in the extension string.