### PR TITLE
Expose 'raw' argument 

### DIFF
--- a/bin/basenji_train.py
+++ b/bin/basenji_train.py
@@ -66,6 +66,9 @@ def main():
   parser.add_option('--tfr_eval', dest='tfr_eval_pattern',
       default=None,
       help='Evaluation TFR pattern string appended to data_dir/tfrecords for subsetting [Default: %default]')
+  parser.add_option('--input_encoded', dest='raw',
+      default=False,
+      help='Check if Input data is one hot encoded or not [Default: %default]')
   (options, args) = parser.parse_args()
 
   if len(args) < 2:
@@ -106,14 +109,16 @@ def main():
     batch_size=params_train['batch_size'],
     shuffle_buffer=params_train.get('shuffle_buffer', 128),
     mode='train',
-    tfr_pattern=options.tfr_train_pattern))
+    tfr_pattern=options.tfr_train_pattern,
+    raw))
 
     # load eval data
     eval_data.append(dataset.SeqDataset(data_dir,
     split_label='valid',
     batch_size=params_train['batch_size'],
     mode='eval',
-    tfr_pattern=options.tfr_eval_pattern))
+    tfr_pattern=options.tfr_eval_pattern,
+    raw))
 
   params_model['strand_pair'] = strand_pairs
 


### PR DESCRIPTION
### Description of your changes
<!--- Changes proposed in this pull request -->
I exposed 'raw' argument to CLI, so user can check whether the input data is already one-hot-encoded, which makes the explore_model.ipynb data loading consistent with the input shape and format required for a model prediction.
### Issue ticket number and link
<!--- Please include the JIRA ticket and link -->
#173 
### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation add / update

### (If applicable) How has this been tested?
<!--- Please describe the tests that you ran to verify your changes. -->
<!--- Include details of your testing environment -->
