### PR TITLE
Closes #199 - Update layers shape in seqnn.py 

### DIFF
--- a/basenji/seqnn.py
+++ b/basenji/seqnn.py
@@ -187,7 +187,7 @@ class SeqNN():
       self.model_strides.append(1)
       for layer in self.model.layers:
         if hasattr(layer, 'strides') or hasattr(layer, 'size'):
-          stride_factor = layer.input_shape[1] / layer.output_shape[1]
+          stride_factor = layer.input.shape[1] / layer.output.shape[1]
           self.model_strides[-1] *= stride_factor
       self.model_strides[-1] = int(self.model_strides[-1])
 


### PR DESCRIPTION
### Description of your changes
Update layers shape in seqnn.py, as `input_shape` and  `output_shape` are deprecated.

### Issue ticket number and link
Fixes issue #199

### Type of change
- [ ]  Bug fix

### (If applicable) How has this been tested?
I tested the updated script on a GNU/Linux workstation (Ubuntu 20.04.1) using a conda environment with keras==3.6.0 installed.