### PR TITLE
Fix #210: typo in bam_cov.py

### DIFF
--- a/bin/bam_cov.py
+++ b/bin/bam_cov.py
@@ -1580,7 +1580,7 @@ class GenomeCoverage:
 
         # reverse
         rcov_out = pyBigWig.open('%s-.bw' % os.path.splitext(output_file)[0], 'w')
-        rcout_out.addHeader(headers)
+        rcov_out.addHeader(headers)
 
       else:
         cov_out = pyBigWig.open(output_file, 'w')


### PR DESCRIPTION
### Description of your changes
Fixes a typo in the variable name used for reverse strand BigWig output in the write method of GenomeCoverage. Changes `rcout_out` → `rcov_out`.

### Issue ticket number and link
No issue tracker available, but context discussed in opened GitHub Issue: #210 

### Type of change
- [x] Bug fix
- [ ] New feature
   - [ ] Backwards Incompatible?
- [ ] Refactoring / code clean-up
- [ ] Documentation add / update
- [ ] Automated Test
- [ ] Other (please specify)

### (If applicable) How has this been tested?
Created an environment based on `prespecified.yml` and `requirements.txt`. Ran the script with `--strand` flag. Confirmed that both +.bw and -.bw output files are created without triggering a NameError.
